### PR TITLE
feat: support for wrapped errors

### DIFF
--- a/middleware/errormiddleware_test.go
+++ b/middleware/errormiddleware_test.go
@@ -43,6 +43,28 @@ func TestMapSimpleErrorToStatusCode(t *testing.T) {
 	assert.Equal(t, recorder.Result().StatusCode, http.StatusNotFound)
 }
 
+func TestMapWrappedErrorToStatusCode(t *testing.T) {
+	wrapped := fmt.Errorf("wrapped error: %w", NotFoundError)
+
+	// Arrange
+	router := gin.Default()
+	router.Use(
+		ErrorHandler(
+			Map(NotFoundError).ToStatusCode(http.StatusNotFound),
+		))
+
+	// Act
+	router.GET("/", func(c *gin.Context) {
+		_ = c.Error(wrapped)
+	})
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest("GET", "/", nil))
+
+	// Assert
+	assert.Equal(t, recorder.Result().StatusCode, http.StatusNotFound)
+}
+
 func TestMapErrorStructToStatusCode(t *testing.T) {
 	// Arrange
 	router := gin.Default()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/gin-gonic/gin"
@@ -18,7 +19,7 @@ func ErrorHandler(errMap ...*errorMapping) gin.HandlerFunc {
 
 		for _, e := range errMap {
 			for _, e2 := range e.fromErrors {
-				if lastErr.Err == e2 {
+				if errors.Is(lastErr.Err, e2) {
 					e.toResponse(context, lastErr.Err)
 				} else if isType(lastErr.Err, e2) {
 					e.toResponse(context, lastErr.Err)


### PR DESCRIPTION
Equality comparsion doesn't support wrapped errors, the right solution is to use `errors.Is`.